### PR TITLE
Endrer databaseskjema: ID som UUID-streng

### DIFF
--- a/api/prisma/migrations/20240501145959_id_as_uuid/migration.sql
+++ b/api/prisma/migrations/20240501145959_id_as_uuid/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - The primary key for the `User` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP CONSTRAINT "User_pkey",
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "User_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "User_id_seq";

--- a/api/prisma/migrations/20240501153055_targets_as_uuid/migration.sql
+++ b/api/prisma/migrations/20240501153055_targets_as_uuid/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "targets" SET DATA TYPE TEXT[];

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -11,12 +11,12 @@ datasource db {
 }
 
 model User {
-  id        Int     @id @default(autoincrement())
+  id        String  @id @default(uuid())
   email     String  @unique
   name      String  @unique
   admin     Boolean @default(false)
   password  String
-  targets   Int[]
+  targets   String[]
   lives     Int     @default(3)
   level     Int     @default(1)
   photoHref String?

--- a/api/src/authenticate.ts
+++ b/api/src/authenticate.ts
@@ -7,7 +7,7 @@ import jwt from "jsonwebtoken";
 
 const prisma = new PrismaClient();
 
-const getToken = (id: number) => {
+const getToken = (id: string) => {
   return jwt.sign({ id: id }, process.env.PASSPORT_KEY as string, {
     expiresIn: '36h'
   });

--- a/api/src/clients/clients.ts
+++ b/api/src/clients/clients.ts
@@ -1,15 +1,15 @@
 import type { Response} from "express";
 // Store clients
-let clients: { id: number, res: Response }[] = [];
+let clients: { id: string, res: Response }[] = [];
 
-export const addClient = (id: number, res: Response) => {
+export const addClient = (id: string, res: Response) => {
   const newClient = { id, res };
   clients.push(newClient);
   console.log('New client connected:', id);
   console.log('Current clients:', clients.map(client => client.id));
 }
 
-export const removeClient = (id: number) => {
+export const removeClient = (id: string) => {
   clients = clients.filter(client => client.id !== id);
   console.log('Client disconnected:', id);
   console.log('Current clients:', clients.map(client => client.id));
@@ -27,13 +27,13 @@ export const sendEventToAllClients = (data: EventData) => {
 }
 
 // Function to send an event to all connected clients
-export const sendEventToClient = (data: EventData, clientId: number) => {
+export const sendEventToClient = (data: EventData, clientId: string) => {
   clients.find(client => client.id === clientId)
     ?.res.write(`data: ${JSON.stringify(data)}\n\n`);
 }
 
 // Function to send an event to all connected clients
-export const sendEventToSeveralClients = (data: EventData, clientIds: number[]) => {
+export const sendEventToSeveralClients = (data: EventData, clientIds: string[]) => {
   clients.find(client => clientIds.includes(client.id))
     ?.res.write(`data: ${JSON.stringify(data)}\n\n`);
 }

--- a/api/src/db/repository.ts
+++ b/api/src/db/repository.ts
@@ -30,7 +30,7 @@ export const prisma = new PrismaClient().$extends({
         });
       },
 
-      async getName(userId: number) {
+      async getName(userId: string) {
         const user = await prisma.user.findFirst({
           where: {
             id: userId
@@ -42,7 +42,7 @@ export const prisma = new PrismaClient().$extends({
         return user.name
       },
 
-      async getUser(userId: number) {
+      async getUser(userId: string) {
         return prisma.user.findFirst({
           where: {
             id: userId
@@ -56,8 +56,8 @@ export const prisma = new PrismaClient().$extends({
         })
       },
 
-      async getTargets(userId: number) {
-        const userWithTargets: { targets: number[] } = await prisma.user.findFirst({
+      async getTargets(userId: string) {
+        const userWithTargets: { targets: string[] } = await prisma.user.findFirst({
           where: {
             id: userId
           },
@@ -68,7 +68,7 @@ export const prisma = new PrismaClient().$extends({
         return userWithTargets.targets
       },
 
-      async levelUp(userId: number) {
+      async levelUp(userId: string) {
         await prisma.user.update({
           where: {
             id: userId
@@ -81,8 +81,8 @@ export const prisma = new PrismaClient().$extends({
         })
       },
 
-      async setTargetByIndex(userId: number, targetIndex: | 0 | 1 | 2, targetId: number) {
-        const originalTargets: number[] = await prisma.user.getTargets(userId);
+      async setTargetByIndex(userId: string, targetIndex: | 0 | 1 | 2, targetId: string) {
+        const originalTargets: string[] = await prisma.user.getTargets(userId);
         const originalTargetAtIndex = originalTargets[targetIndex];
 
         const updatedTargets = [...originalTargets];
@@ -99,19 +99,19 @@ export const prisma = new PrismaClient().$extends({
         return originalTargetAtIndex
       },
 
-      async removeTarget(userId: number, targetIndex: | 0 | 1 | 2) {
-        return prisma.user.setTargetByIndex(userId, targetIndex, -1)
+      async removeTarget(userId: string, targetIndex: | 0 | 1 | 2) {
+        return prisma.user.setTargetByIndex(userId, targetIndex, '')
       },
 
-      async findUserWithTargetAtIndex(targetId: number, targetIndex: | 0 | 1 | 2) {
+      async findUserWithTargetAtIndex(targetId: string, targetIndex: | 0 | 1 | 2) {
         const users = await prisma.user.findMany();
         return users.find(user => {
           return user.targets[targetIndex] === targetId
         })
       },
 
-      async claimTarget(winnerId: number, loserId: number) {
-        const winnerTargets: number[] = await prisma.user.getTargets(winnerId);
+      async claimTarget(winnerId: string, loserId: string) {
+        const winnerTargets: string[] = await prisma.user.getTargets(winnerId);
         if (winnerTargets.includes(loserId)) {
           // Her har vi logikk for at utfordreren vant, og overtar taperens mål med samme indeks
           const whichGameLoop = winnerTargets.indexOf(loserId) as 0 | 1 | 2;
@@ -133,7 +133,7 @@ export const prisma = new PrismaClient().$extends({
         }
       },
 
-      async loseLife(userId: number) {
+      async loseLife(userId: string) {
         await prisma.user.update({
           where: {
             id: userId
@@ -146,7 +146,7 @@ export const prisma = new PrismaClient().$extends({
         })
       },
 
-      async isAlive(userId: number) {
+      async isAlive(userId: string) {
         const user = await prisma.user.findFirst({
           where: {
             id: userId
@@ -168,8 +168,8 @@ export const prisma = new PrismaClient().$extends({
           }
         })
       },
-      async assignTargets(tMap: TargetMap, assassins: number[]) {
-        await Promise.all(assassins.map(async (k: number) => {
+      async assignTargets(tMap: TargetMap, assassins: string[]) {
+        await Promise.all(assassins.map(async (k: string) => {
           await prisma.user.update({
             where: {
               id: k
@@ -191,7 +191,7 @@ const createPassword = () => {
   return `${randomPassComponent}-${randomInt}`
 }
 
-export const fetchUser = async (userId: number): Promise<Partial<User>> => {
+export const fetchUser = async (userId: string): Promise<Partial<User>> => {
   return prisma.user.findFirst({
     where: {
       id: userId

--- a/api/src/dueling/dueling.ts
+++ b/api/src/dueling/dueling.ts
@@ -1,7 +1,7 @@
 import { notifyAboutDefeat, notifyAboutVictory } from "../messages/duel-results";
 import { prisma } from "../db/repository";
 
-export const initiateDuel = async (challengerId: number, targetId: number) => {
+export const initiateDuel = async (challengerId: string, targetId: string) => {
   const challenger = await prisma.user.getUser(challengerId);
   const target = await prisma.user.getUser(targetId);
   const duelOutcome = resolveDuel(challengerId, challenger.level, targetId, target.level);
@@ -15,11 +15,11 @@ export const initiateDuel = async (challengerId: number, targetId: number) => {
 }
 
 type DuelOutcome = {
-  winner: number;
-  loser: number;
+  winner: string;
+  loser: string;
 }
 
-const resolveDuel = (challengerId: number, challengerLevel: number, targetId: number, targetLevel: number): DuelOutcome => {
+const resolveDuel = (challengerId: string, challengerLevel: number, targetId: string, targetLevel: number): DuelOutcome => {
   // Calculate level difference
   const levelDifference = challengerLevel - targetLevel;
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -22,7 +22,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use(passport.initialize());
 
 app.get("/", (req, res) => {
-  res.send("Hello via Bun!");
+  res.send("Velkommen til Hodejeger-API-et!");
 });
 
 app.use('/login', loginRouter);

--- a/api/src/messages/duel-results.ts
+++ b/api/src/messages/duel-results.ts
@@ -1,14 +1,14 @@
 import { prisma } from "../db/repository";
 import { sendEventToClient } from "../clients/clients";
 
-export const notifyAboutVictory = async (winnerId: number, loserId: number) => {
+export const notifyAboutVictory = async (winnerId: string, loserId: string) => {
   const loserName = await prisma.user.getName(loserId);
   const winner = await prisma.user.getUser(winnerId);
   const winnerMessage = `Du vant mot ${loserName}, og er nå level ${winner.level}!`
   sendEventToClient({ message: winnerMessage }, winnerId);
 }
 
-export const notifyAboutDefeat = async (winnerId: number, loserId: number) => {
+export const notifyAboutDefeat = async (winnerId: string, loserId: string) => {
   const winnerName = await prisma.user.getName(winnerId);
   const loser = await prisma.user.getUser(loserId);
   const loserMessage = getLoserMessage(winnerName, loser.lives)

--- a/api/src/routes/initiate.ts
+++ b/api/src/routes/initiate.ts
@@ -10,8 +10,8 @@ router.route('/')
     res.sendStatus(204);
   })
   .post(cors.corsWithSpecifiedOriginAndCredentials, authenticate.verifyUser, authenticate.verifyAdmin, async (req, res) => {
-    const allUsers: { id: number }[] = await prisma.user.allUserIds()
-    const extractedIds: number[] = allUsers.map(v => v.id)
+    const allUsers: { id: string }[] = await prisma.user.allUserIds()
+    const extractedIds: string[] = allUsers.map(v => v.id)
     const assignedTargets = assignTargets(extractedIds)
     await prisma.user.assignTargets(assignedTargets, extractedIds)
     res.status(204).end()
@@ -19,10 +19,10 @@ router.route('/')
 
 
 export type TargetMap = {
-  [key: string]: number[]
+  [key: string]: string[]
 }
 
-export const assignTargets = (userIds: number[]) => {
+export const assignTargets = (userIds: string[]) => {
   const tmp = shuffle([...userIds])
   // Forskyver første løkke sånn at man ikke får seg selv som mål
   //tmp.push(tmp.shift()!)
@@ -43,22 +43,22 @@ export const assignTargets = (userIds: number[]) => {
   return userMap
 }
 
-const shuffleAndAssignTargets = (loops: number[][], userIds: number[]) => {
+const shuffleAndAssignTargets = (loops: string[][], userIds: string[]) => {
   loops[0] = shuffle(userIds)
   loops[1] = shuffle(userIds)
   loops[2] = shuffle(userIds)
 
   const userMap: TargetMap  = {}
 
-  const assignTargetForAssassin = (loop: number[], loopNum: number, ind: number) => {
-    const curAssassin = loop[ind].toString()
+  const assignTargetForAssassin = (loop: string[], loopNum: number, ind: number) => {
+    const curAssassin = loop[ind]
     userMap[curAssassin][loopNum] = loop[(ind+1) % userIds.length]
   }
 
-  userIds.map((id: number) => {
-    userMap[id.toString()] = [-1, -1, -1]
+  userIds.map((id: string) => {
+    userMap[id.toString()] = ['', '', '']
   })
-  userIds.map((id: number, index: number) => {
+  userIds.map((id: string, index: number) => {
     assignTargetForAssassin(loops[0], 0, index)
     assignTargetForAssassin(loops[1], 1, index)
     assignTargetForAssassin(loops[2], 2, index)
@@ -66,8 +66,8 @@ const shuffleAndAssignTargets = (loops: number[][], userIds: number[]) => {
   return userMap
 }
 
-const shuffle = (array: number[]) => {
-  const resultArray: number[] = [...array]
+const shuffle = (array: string[]) => {
+  const resultArray: string[] = [...array]
   let currentIndex = array.length,  randomIndex;
 
   //For å beholde loopen setter vi første til å være siste i forrige array
@@ -90,13 +90,14 @@ const shuffle = (array: number[]) => {
   return resultArray;
 }
 
-const validateArray = (userMap: TargetMap | undefined, userIds: number[]) => {
+const validateArray = (userMap: TargetMap | undefined, userIds: string[]) => {
   let i = 0;
   while(i < userIds.length) {
     const key = userIds[i].toString()
     const curTargets = userMap[key]
 
-    if (curTargets[0] === curTargets[1] || curTargets[0] === curTargets[2] || curTargets[1] === curTargets[2]) { //sjekker om samme person har flere av samme mål
+    //sjekker om samme person har flere av samme mål
+    if (curTargets[0] === curTargets[1] || curTargets[0] === curTargets[2] || curTargets[1] === curTargets[2]) {
       console.log("Samme person har flere av samme mål")
       return false
     }

--- a/api/src/routes/targets.ts
+++ b/api/src/routes/targets.ts
@@ -6,7 +6,7 @@ import cors from "../cors";
 const router = express.Router();
 
 type Target = {
-  id: number,
+  id: string,
   name: string,
   photoHref: string
 }
@@ -20,8 +20,8 @@ router.route('/')
       const targetList = await prisma.user.getTargets(req.user!.id)
       if (targetList && targetList.length != 0) {
         const targetsWithInfo = await Promise.all(targetList
-          .filter((targetId: number) => targetId !== -1)
-          .map(async (targetId: number): Promise<Target> => {
+          .filter((targetId: string) => targetId !== '')
+          .map(async (targetId: string): Promise<Target> => {
           const targetUser = await fetchUser(targetId);
           return { id: targetUser.id, name: targetUser.name, photoHref: targetUser.photoHref }
         }));


### PR DESCRIPTION
Tenker å bruke `id` som felles identifikator mellom backend og autentiseringsserver. Endrer derfor databaseskjema til å ha `id` som `string` med `uuid`-verdier. Dette gjelder både `id`- og `targets`-kolonnen.

Endrer også all bruk av ID-er (særlig `db/repository.ts`) til å referere til strenger.